### PR TITLE
Update the certificate fingerprint in the docs

### DIFF
--- a/docs/2.0/api/app.md
+++ b/docs/2.0/api/app.md
@@ -65,7 +65,7 @@ The list of pinned certificates has to be in the form of `[{host: <string>, hash
 - The `hash` attribute is the base64 encoded sha256 fingerprint of the _subjectPublicKeyInfo_, prefixed with `sha256/`.
 - The `algorithm` attribute denotes the public key algorithm of the SSL certificate and can have the values `RSA2048`, `RSA4096` or `ECDSA256`. This attribute is only required on iOS.
 
-Example: `[{host: 'freegeoip.net', hash: 'sha256/eTPz+5X4FcoK5fW+I0Wt/9y2vOkU3UMmVnDs7yGUJf8', algorithm: 'RSA4096'}]`
+Example: `[{host: 'freegeoip.net', hash: 'sha256/+SVYjThgePRQxQ0e8bWTQDRtPYR/xBRufqyMoeaWteo=', algorithm: 'ECDSA256'}]`
 
 For further details see https://www.owasp.org/index.php/Certificate_and_Public_Key_Pinning.
 

--- a/docs/latest/api/app.md
+++ b/docs/latest/api/app.md
@@ -65,7 +65,7 @@ The list of pinned certificates has to be in the form of `[{host: <string>, hash
 - The `hash` attribute is the base64 encoded sha256 fingerprint of the _subjectPublicKeyInfo_, prefixed with `sha256/`.
 - The `algorithm` attribute denotes the public key algorithm of the SSL certificate and can have the values `RSA2048`, `RSA4096` or `ECDSA256`. This attribute is only required on iOS.
 
-Example: `[{host: 'freegeoip.net', hash: 'sha256/eTPz+5X4FcoK5fW+I0Wt/9y2vOkU3UMmVnDs7yGUJf8', algorithm: 'RSA4096'}]`
+Example: `[{host: 'freegeoip.net', hash: 'sha256/+SVYjThgePRQxQ0e8bWTQDRtPYR/xBRufqyMoeaWteo=', algorithm: 'ECDSA256'}]`
 
 For further details see https://www.owasp.org/index.php/Certificate_and_Public_Key_Pinning.
 


### PR DESCRIPTION
The certificate fingerprint for freegeoip.net appears to be wrong.
This was discovered while writing the blog post for certificate
pinning. This change-set updates the fingerprint. We used [1]
to determine the fingerprint which was a suggestion found on [2].

[1] https://www.ssllabs.com/ssltest/analyze.html
[2] https://stackoverflow.com/questions/40404963/how-do-i-get-public-key-hash-for-ssl-pinning

This new fingerprint was tested and appears to work.