### PR TITLE
Fix DI example links

### DIFF
--- a/tools/update.js
+++ b/tools/update.js
@@ -67,7 +67,7 @@ const preRelease = process.argv[2] === 'pre-release';
   copyDir(DECO_DI_DIR, targetDiDir);
   console.log('Fix tabris-decorators example links');
   replaceInAll(targetDataBindingDir, EXAMPLES_NEEDLE, examplesRepl);
-  replaceInAll(targetDiDir, EXAMPLES_NEEDLE, + examplesRepl);
+  replaceInAll(targetDiDir, EXAMPLES_NEEDLE, examplesRepl);
   console.log(`Update ${targetYml}`);
   updateTargetYml(targetYml, 'Data Binding', targetDataBindingDir);
   updateTargetYml(targetYml, 'Dependency Injection', targetDiDir);


### PR DESCRIPTION
Replacement string got converted to a number, what was not expected.
Note that this didn't have any consequence yet, since no DI articles
contain links to examples.

Change-Id: I659daf35a2cf2fcb84b72ef73560a129498fa16f